### PR TITLE
chore: ignore rubocop error

### DIFF
--- a/lib/omniauth/strategies/realme.rb
+++ b/lib/omniauth/strategies/realme.rb
@@ -5,7 +5,7 @@ require 'ruby-saml'
 
 module OmniAuth
   module Strategies
-    class Realme
+    class Realme # rubocop:disable Metrics/ClassLength
       class Error < StandardError; end
       class RelayStateTooLongError < Error; end
 


### PR DESCRIPTION
Rubocop doesn't like the size of this class for some reason, but I don't think it would be useful to pull any of the contents out into another file so instead I've just disabled the warning